### PR TITLE
debugger: use tarantooldb org

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -28,5 +28,5 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: tarantool-lua-debugger-vscode
-          path: tarantool-lua-debugger-vscode-*.vsix
+          name: tarantool-lua-debugger
+          path: tarantool-lua-debugger-*.vsix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,4 +40,4 @@ jobs:
         uses: shogo82148/actions-upload-release-asset@v1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./tarantool-lua-debugger-vscode-*.vsix
+          asset_path: ./tarantool-lua-debugger-*.vsix

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
 	"eslint.workingDirectories": [
 		"./debugger",
 		"./extension"
-	]
+	],
+	"Lua.workspace.checkThirdParty": false
 }

--- a/extension/constants.ts
+++ b/extension/constants.ts
@@ -1,1 +1,1 @@
-export const EXTENSION_ID = "tarantool.tarantool-lua-debugger-vscode";
+export const EXTENSION_ID = "tarantooldb.tarantool-lua-debugger";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "tarantool-lua-debugger-vscode",
-  "version": "0.3.3",
+  "name": "tarantool-lua-debugger",
+  "version": "0.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "tarantool-lua-debugger-vscode",
-      "version": "0.3.3",
+      "name": "tarantool-lua-debugger",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "vscode-debugadapter": "^1.48.0"

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "tarantool-lua-debugger-vscode",
-  "publisher": "tarantool",
-  "version": "0.4.0",
+  "name": "tarantool-lua-debugger",
+  "publisher": "tarantooldb",
+  "version": "0.4.1",
   "description": "Tarantool Lua Debugger - tarantool lua debugger with no dependencies",
   "displayName": "Tarantool Lua Debugger",
   "icon": "resources/tarantool-logo-small_128x128.png",
   "repository": {
     "type": "github",
-    "url": "https://github.com/usenko-timur/tarantool-local-lua-debugger-vscode.git"
+    "url": "https://github.com/tarantool/tarantool-lua-debugger-vscode.git"
   },
   "author": "usenko-timur@users.noreply.github.com",
   "license": "MIT",


### PR DESCRIPTION
Change organization name to 'tarantooldb' as we were unable to restore access to TaranTOOL organization on Azure.

Assumed to be published as version 0.4.1.