### PR TITLE
Fix incompatibilities with pre tarantool 2.10.4 version

### DIFF
--- a/debugger/debugger.ts
+++ b/debugger/debugger.ts
@@ -39,7 +39,7 @@ import {Thread, mainThread, mainThreadName, isThread} from "./thread";
 import * as tarantool from "tarantool";
 
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-const luaTarantoolGetSources = tarantool.debug.getsources ?? function(filePath: string) {
+const luaTarantoolGetSources = tarantool?.debug?.getsources ?? function(filePath: string) {
     return null;
 };
 

--- a/debugger/tsconfig.json
+++ b/debugger/tsconfig.json
@@ -21,7 +21,7 @@
         "noHeader": true,
         "luaBundle": "lldebugger.lua",
         "luaBundleEntry": "lldebugger.ts",
-        "luaLibImport": "none",
+        "luaLibImport": "require",
         "noResolvePaths": ["tarantool"]
     }
 }


### PR DESCRIPTION
Use optional chaining for access to `tarantool.debug.getsources()`

Closes #4